### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/fastcampus-project-board/build.gradle
+++ b/fastcampus-project-board/build.gradle
@@ -24,6 +24,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation('org.springframework.boot:spring-boot-starter-data-rest')
+    implementation('org.springframework.data:spring-data-rest-hal-explorer')
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/fastcampus-project-board/src/main/resources/application.yaml
+++ b/fastcampus-project-board/src/main/resources/application.yaml
@@ -29,7 +29,10 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
   sql.init.mode: always
-
+  data:
+    rest:
+      base-path: /api
+      detection-strategy: annotated
 ---
 
 spring:

--- a/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
@@ -1,0 +1,64 @@
+package com.fastcampus.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+  private final MockMvc mvc;
+
+  public DataRestTest(@Autowired MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  @DisplayName("[api] 게시글 리스트 조회")
+  @Test
+  void giveNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+    mvc.perform(get("/api/articles"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+  @DisplayName("[api] 게시글 단건 조회")
+  @Test
+  void giveNothing_whenRequestingArticle_thenReturnsArticlesJsonResponse() throws Exception {
+    mvc.perform(get("/api/articles/1"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+  @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+  @Test
+  void giveNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticlesJsonResponse() throws Exception {
+    mvc.perform(get("/api/articles/1/articleComments"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+  @DisplayName("[api] 댓글 리스트 조회")
+  @Test
+  void giveNothing_whenRequestingArticleComments_thenReturnsArticlesJsonResponse() throws Exception {
+    mvc.perform(get("/api/articleComments"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+  @DisplayName("[api] 댓글 단건 조회")
+  @Test
+  void giveNothing_whenRequestingArticleComment_thenReturnsArticlesJsonResponse() throws Exception {
+    mvc.perform(get("/api/articleComments/1"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 api 들의 존재 여부만 체크하게끔 통합테스트 작성
